### PR TITLE
fix(cmd): Replace old folder name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	repoName = ".dotfiles_badm"
+	repoName = ".dotfiles"
 
 	var err error
 


### PR DESCRIPTION
Remove old Dotfiles folder suffix `_badm` and use just `.dotfiles`.

In future more configuration regarding the Dotfiles folder will be added.